### PR TITLE
Insert em/ex-based spacing after font selection.

### DIFF
--- a/beamerthemeucl.sty
+++ b/beamerthemeucl.sty
@@ -57,8 +57,8 @@
 \defbeamertemplate{headline}{section}{%
   \begin{beamercolorbox}[ignorebg,ht=\bannerheight]{section in head/foot}%
     \vbox to\bannerheight{
-      \vspace{1em}%
       \usebeamerfont{section in head/foot}%
+      \vspace{1em}%
       \hspace{1em}\insertsectionhead%
       \ifx\insertsubsectionhead\@empty%
       \else%
@@ -96,10 +96,10 @@
       \hspace{1em}%
       \usebeamertemplate{department}%
       \par%
-      \vspace*{.5ex}%
-      \hspace{1em}%
       \usebeamerfont*{subsection in head/foot}%
       \usebeamercolor[fg]{subsection in head/foot}%
+      \vspace*{.5ex}%
+      \hspace{1em}%
       \usebeamertemplate{subdepartment}%
       \par%
       \vfil}%


### PR DESCRIPTION
On two occasions, `\usebeamerfont` was called _after_ inserting spacing that varies depending on the font size. This change swaps those calls around, so the spacing matches the font size again.